### PR TITLE
fix(ArvoriaBinaria.java): correção remover recursivo

### DIFF
--- a/src/lib/ArvoreBinaria.java
+++ b/src/lib/ArvoreBinaria.java
@@ -156,7 +156,7 @@ public class ArvoreBinaria<T> implements IArvoreBinaria<T> {
             else {
                 No<T> menor = encontrarMenor(raiz.getFilhoDireita());
                 raiz.setValor(menor.getValor());
-                raiz.setFilhoDireita(removerRecursivo(raiz.getFilhoDireita(), menor.getValor(), noRemovido));
+                raiz.setFilhoDireita(removerRecursivo(raiz.getFilhoDireita(), menor.getValor(), new No<T>(null)));
             }
         }
         return raiz;


### PR DESCRIPTION
Agora o retorno do remover está correto em todos os casos, incluindo na remoção de um nó que possui 2 filhos.